### PR TITLE
Some more CLI options for launching

### DIFF
--- a/src/amidst/Amidst.java
+++ b/src/amidst/Amidst.java
@@ -2,16 +2,19 @@ package amidst;
 
 import java.awt.Image;
 import java.io.File;
+import java.net.MalformedURLException;
 
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
 import com.google.gson.Gson;
 
+import MoF.FinderWindow;
 import MoF.Google;
 import amidst.gui.version.VersionSelectWindow;
 import amidst.logging.FileLogger;
 import amidst.logging.Log;
+import amidst.minecraft.Minecraft;
 import amidst.minecraft.MinecraftUtil;
 import amidst.preferences.BiomeColorProfile;
 import amidst.resources.ResourceLoader;
@@ -51,7 +54,20 @@ public class Amidst {
 		System.setProperty("sun.java2d.accthreshold", "0");
 		BiomeColorProfile.scan();
 		
-		new VersionSelectWindow();
+		if (Options.instance.minecraftJar != null)
+		{
+			try {
+				Util.setProfileDirectory(Options.instance.minecraftPath);
+				MinecraftUtil.setBiomeInterface(new Minecraft(new File(Options.instance.minecraftJar)).createInterface());
+				new FinderWindow();
+			} catch (MalformedURLException e) {
+				Log.crash(e, "MalformedURLException on Minecraft load.");
+			}
+		}
+		else
+		{
+			new VersionSelectWindow();
+		}
 	}
 	
 	public static boolean isOSX() {

--- a/src/amidst/Options.java
+++ b/src/amidst/Options.java
@@ -46,6 +46,12 @@ public enum Options {
 	@Option (name="-mcpath", usage="Sets the path to the .minecraft directory.", metaVar="<path>")
 	public String minecraftPath;
 	
+	@Option (name="-mcjar", usage="Sets the path to the minecraft .jar", metaVar="<path>")
+	public String minecraftJar;
+	
+	@Option (name="-mcjson", usage="Sets the path to the minecraft .json", metaVar="<path>")
+	public String minecraftJson;
+	
 	private Options() {
 		seed = 0L;
 		seedText = null;

--- a/src/amidst/gui/menu/AmidstMenu.java
+++ b/src/amidst/gui/menu/AmidstMenu.java
@@ -234,10 +234,14 @@ public class AmidstMenu extends JMenuBar {
 						fc.setFileFilter(SaveLoader.getFilter());
 						fc.setAcceptAllFileFilterUsed(false);
 						fc.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+						File savesDir = null;
 						if (Util.profileDirectory != null)
-							fc.setCurrentDirectory(new File(Util.profileDirectory, "saves"));
+							savesDir = new File(Util.profileDirectory, "saves");
 						else
-    						fc.setCurrentDirectory(new File(Util.minecraftDirectory, "saves"));
+							savesDir = new File(Util.minecraftDirectory, "saves");
+						if (!savesDir.mkdirs())
+							return;
+						fc.setCurrentDirectory(savesDir);
 						fc.setFileHidingEnabled(false);
 						if (fc.showOpenDialog(window) == JFileChooser.APPROVE_OPTION) {
 							File f = fc.getSelectedFile();

--- a/src/amidst/minecraft/Minecraft.java
+++ b/src/amidst/minecraft/Minecraft.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import amidst.Options;
 import amidst.Util;
 import amidst.bytedata.ByteClass;
 import amidst.bytedata.ByteClass.AccessFlags;
@@ -285,7 +286,7 @@ public class Minecraft {
 		
 		for (int i = 0; i < profile.libraries.size(); i++) {
 			JarLibrary library = profile.libraries.get(i);
-			if (library.isActive() && library.getFile().exists()) {
+			if (library.isActive() && library.getFile() != null && library.getFile().exists()) {
 				try {
 					libraries.add(library.getFile().toURI().toURL());
 					Log.i("Found library: " + library.getFile());
@@ -324,7 +325,9 @@ public class Minecraft {
 	*/
 	
 	public void use() {
-		File librariesJson = new File(jarFile.getPath().replace(".jar", ".json"));
+		File librariesJson = Options.instance.minecraftJson == null ?
+				new File(jarFile.getPath().replace(".jar", ".json"))
+			  : new File(Options.instance.minecraftJson);
 		if (librariesJson.exists()) {
 			Stack<URL> libraries = getLibraries(librariesJson);
 			URL[] libraryArray = new URL[libraries.size() + 1];


### PR DESCRIPTION
I'm currently implementing support for AMIDST in MultiMC, similar to the existing MCEdit support. For that I'm requiring some more control over AMIDST than available, as the directory structure of MultiMC is slightly different than that of vanilla Minecraft.

This PR works together with MultiMC/MultiMC5@77251d1378fbfe99a56102bc86ecc3e94551a8c1
