### PR TITLE
Fix a bug and add -mclibs CLI option

### DIFF
--- a/src/amidst/Amidst.java
+++ b/src/amidst/Amidst.java
@@ -35,13 +35,14 @@ public class Amidst {
 			}
 		});
 		CmdLineParser parser = new CmdLineParser(Options.instance); 
-		Util.setMinecraftDirectory();
 		try {
 			parser.parseArgument(args);
 		} catch (CmdLineException e) {
 			Log.w("There was an issue parsing command line options.");
 			e.printStackTrace();
 		}
+		Util.setMinecraftDirectory();
+		Util.setMinecraftLibraries();
 		
 		if (Options.instance.logPath != null)
 			Log.addListener("file", new FileLogger(new File(Options.instance.logPath)));

--- a/src/amidst/Options.java
+++ b/src/amidst/Options.java
@@ -51,6 +51,9 @@ public enum Options {
 	
 	@Option (name="-mcjson", usage="Sets the path to the minecraft .json", metaVar="<path>")
 	public String minecraftJson;
+
+	@Option (name="-mclibs", usage="Sets the path to the libraries/ folder", metaVar="<path>")
+	public String minecraftLibraries;
 	
 	private Options() {
 		seed = 0L;

--- a/src/amidst/Util.java
+++ b/src/amidst/Util.java
@@ -78,6 +78,11 @@ public class Util {
 		}
 		minecraftDirectory = (mcDir != null) ? mcDir : new File(homeDirectory, ".minecraft");
 	}
+
+	public static File minecraftLibraries;
+	public static void setMinecraftLibraries() {
+		minecraftLibraries = (Options.instance.minecraftLibraries == null) ? new File(minecraftDirectory, "libraries") : new File(Options.instance.minecraftLibraries);
+	}
 	
 	public static File profileDirectory;
 	public static void setProfileDirectory(String gameDir) {

--- a/src/amidst/json/JarLibrary.java
+++ b/src/amidst/json/JarLibrary.java
@@ -30,7 +30,7 @@ public class JarLibrary {
 	
 	public File getFile() {
 		if (file == null) {
-			String searchPath = Util.minecraftDirectory + "/libraries/";
+			String searchPath = Util.minecraftLibraries.getAbsolutePath() + "/";
 			String[] pathSplit = name.split(":");
 			pathSplit[0] = pathSplit[0].replace('.', '/');
 			for (int i = 0; i < pathSplit.length; i++)


### PR DESCRIPTION
There was a bug in Amidst.java; the call to Util.setMinecraftDirectory() happened before the CLI arguments where parsed, and thus Options.instance.minecraftPath wasn't populated yet.

This also adds a -mclibs CLI option which was forgotten in the last PR.